### PR TITLE
Catkin macros for rosjava repos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosjava_core)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED rosjava_tools)
+
+catkin_rosjava_setup()
 
 catkin_package()
-
-execute_process(
-  COMMAND ./gradlew
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
 

--- a/package.xml
+++ b/package.xml
@@ -10,5 +10,6 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rosjava_tools</build_depend>
 </package>
 


### PR DESCRIPTION
This is how I'm currently catkinizing rosjava repos. For a test, follow the [instructions](http://ros.org/wiki/sig/Rosjava/Android%20Development%20Environment/hydro). Other documentation is in [rosjava_tools](http://ros.org/wiki/rosjava_tools/hydro). Some points:
- Lets you sequence builds across repos via package.xml build_depend tags and cmake add_dependencies.
- Puts the build step in the cmake 'make' invocation via dummy targets rather than in the configuration step.
- Also adds a global gradle clean target so you can clean multiple gradle packages across repos at once.

To play the devil's advocate - we were thinking about a super gradle project which would effectively do what catkin does with cmake across repos. Some problems with this approach that I can see:
- You can't build rosjava_core without a `setup.bash` invocation somewhere (rosjava_messages). With catkin, that source workspace setup.bash is only created after you invoke catkin. So right now, we need to call catkin anyway.
- Calling catkin, implies we need `package.xml` as well.
- We'll probably also need `package.xml` for bloom at a later point.
- Even if we called out on a super gradle at the root of the source workspace, then it would fail to automatically build other non java (mostly thinking msg packages) packages for you. You'd have to remember and do it by hand first.

So at this point, doing it with a single catkin macro seems like alot less required infrastructure to make things work...for rosjava packages at least.
