### PR TITLE
fix broken link to .rosinstall file, use github

### DIFF
--- a/installing.html
+++ b/installing.html
@@ -65,7 +65,7 @@ mkdir ~/my_workspace
 <span class="nb">cd</span> ~/my_workspace
 rosws init
 rosws merge /opt/ros/groovy/.rosinstall
-rosws merge https://raw.github.com/rosjava/rosjava_core/master/.rosinstall
+rosws set --git --version=groovy-devel rosjava_core 'git://github.com/rosjava/rosjava_core.git'
 rosws update
 <span class="nb">source </span>setup.bash
 </pre></div>


### PR DESCRIPTION
there were several problems:
- the link was broken (branch `master` doesn't exist any more)
- the .rosinstall file still points to the google code repo
