### PR TITLE
fix broken link to rosws doc

### DIFF
--- a/installing.html
+++ b/installing.html
@@ -56,11 +56,10 @@
 See <a class="reference external" href="http://ros.org/wiki/ROS/Installation">ROS/Installation</a> if you need help installing ROS.</p>
 <p>These instructions also assume you are using Ubuntu. However, the differences
 between platforms should be minimal.</p>
-<p>The recommend installation procedure is to use rosws. See the <a class="reference external" href="http://www.ros.org/doc/api/rosinstall/html/rosws_tutorial.html">rosws tutorial</a>
+<p>The recommend installation procedure is to use rosws. See the <a class="reference external" href="http://www.ros.org/doc/independent/api/rosinstall/html/index.html">rosws documentation</a>
 for more information if you find the following quick start instructions to be
 insufficient.</p>
-<div class="highlight-bash"><div class="highlight"><pre>sudo apt-get install python-pip
-sudo pip install --upgrade rosinstall
+<div class="highlight-bash"><div class="highlight"><pre>sudo apt-get install python-rosinstall
 mkdir ~/my_workspace
 <span class="nb">cd</span> ~/my_workspace
 rosws init


### PR DESCRIPTION
Also don't install rosinstall from pip, use the deb version on Ubuntu.
Out-of-date pip versions cause lots of problems.
