### PR TITLE
update .rosinstall to point to github

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -1,4 +1,4 @@
-- hg:
+- git:
     local-name: rosjava_core
-    uri: https://code.google.com/p/rosjava/
-    version: default
+    uri: https://github.com/rosjava/rosjava_core/
+    version: groovy-devel


### PR DESCRIPTION
Your instructions say to use rosws. Please update the instructions to explain that for groovy you need to do 
rosws merge https://raw.github.com/rosjava/rosjava_core/groovy-devel/.rosinstall
and then update the .rosinstall file.
