### PR TITLE
fixed to check if network interface is up or not

### DIFF
--- a/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
+++ b/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
@@ -52,7 +52,13 @@ public class InetAddressFactory {
     }
     List<InetAddress> inetAddresses = Lists.newArrayList();
     for (NetworkInterface networkInterface : networkInterfaces) {
-      inetAddresses.addAll(Collections.list(networkInterface.getInetAddresses()));
+      try{
+        if (networkInterface.isUp()) {
+          inetAddresses.addAll(Collections.list(networkInterface.getInetAddresses()));
+        }
+      } catch (SocketException e) {
+        throw new RosRuntimeException(e);
+      }
     }
     return inetAddresses;
   }

--- a/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
+++ b/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
@@ -52,7 +52,7 @@ public class InetAddressFactory {
     }
     List<InetAddress> inetAddresses = Lists.newArrayList();
     for (NetworkInterface networkInterface : networkInterfaces) {
-      try{
+      try {
         if (networkInterface.isUp()) {
           inetAddresses.addAll(Collections.list(networkInterface.getInetAddresses()));
         }


### PR DESCRIPTION
Hi,

I found a bug when I tried to connect a robot with my smartphone.
Networking errors sometimes occur because the inet addresses of downed network interface can be added to the available list.
So, I added the function of checking if network interface is up or not.
