### PR TITLE
Catkinizing with rosjava_tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosjava_core)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED rosjava_tools)
+
+catkin_rosjava_setup()
 
 catkin_package()
-
-execute_process(
-  COMMAND ./gradlew
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
 

--- a/package.xml
+++ b/package.xml
@@ -10,5 +10,6 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rosjava_tools</build_depend>
 </package>
 


### PR DESCRIPTION
Move the gradle execution from the configure step to the compile step and create targets for cleaning and cross-repo dependency handling as well (all done in rosjava_tools).
