### PR TITLE
Changes for tf2 in hydro - frame naming

### DIFF
--- a/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/TransformBenchmark.java
+++ b/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/TransformBenchmark.java
@@ -59,7 +59,7 @@ public class TransformBenchmark extends AbstractNodeMain {
         connectedNode.getTopicMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
     turtle2.getHeader().setFrameId("world");
     turtle2.setChildFrameId("turtle2");
-    final FrameTransformTree frameTransformTree = new FrameTransformTree(NameResolver.newRoot());
+    final FrameTransformTree frameTransformTree = new FrameTransformTree();
     connectedNode.executeCancellableLoop(new CancellableLoop() {
       @Override
       protected void loop() throws InterruptedException {

--- a/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/FrameName.java
+++ b/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/FrameName.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.ros.rosjava_geometry;
+
+import java.lang.String;
+
+/**
+ * Provides a simple wrapper around strings to represent
+ * frame names with backwards compatibility (pre ros hydro)
+ * catered for by ignoring graph name style leading slashes.
+ *
+ * @author d.stonier@gmail.com (Daniel Stonier)
+ */
+public class FrameName {
+    private static final String LEGACY_SEPARATOR = "/";
+    private String name;
+
+    public static FrameName of(String name) {
+        return new FrameName(name);
+    }
+
+    private FrameName(String name) {
+        this.name = stripLeadingSlash(name);
+    }
+
+    /**
+     * TF2 names (from hydro on) do not make use of leading slashes.
+     */
+    private static String stripLeadingSlash(String name) {
+        return name.replaceFirst("^/", "");
+    }
+
+    public String toString() {
+        return name;
+    }
+
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FrameName other = (FrameName) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/FrameTransform.java
+++ b/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/FrameTransform.java
@@ -19,19 +19,18 @@ package org.ros.rosjava_geometry;
 import com.google.common.base.Preconditions;
 
 import org.ros.message.Time;
-import org.ros.namespace.GraphName;
 
 /**
  * Describes a {@link Transform} from data in the source frame to data in the
  * target frame at a specified {@link Time}.
- * 
+ *
  * @author damonkohler@google.com (Damon Kohler)
  */
 public class FrameTransform {
 
   private final Transform transform;
-  private final GraphName source;
-  private final GraphName target;
+  private final FrameName source;
+  private final FrameName target;
   private final Time time;
 
   public static FrameTransform fromTransformStampedMessage(
@@ -40,12 +39,12 @@ public class FrameTransform {
     String target = transformStamped.getHeader().getFrameId();
     String source = transformStamped.getChildFrameId();
     Time stamp = transformStamped.getHeader().getStamp();
-    return new FrameTransform(transform, GraphName.of(source), GraphName.of(target), stamp);
+    return new FrameTransform(transform, FrameName.of(source), FrameName.of(target), stamp);
   }
 
   /**
    * Allocates a new {@link FrameTransform}.
-   * 
+   *
    * @param transform
    *          the {@link Transform} that transforms data in the {@code source}
    *          frame to data in the {@code target} frame
@@ -57,7 +56,7 @@ public class FrameTransform {
    *          the time associated with this {@link FrameTransform}, can be
    *          {@null}
    */
-  public FrameTransform(Transform transform, GraphName source, GraphName target, Time time) {
+  public FrameTransform(Transform transform, FrameName source, FrameName target, Time time) {
     Preconditions.checkNotNull(transform);
     Preconditions.checkNotNull(source);
     Preconditions.checkNotNull(target);
@@ -71,11 +70,11 @@ public class FrameTransform {
     return transform;
   }
 
-  public GraphName getSourceFrame() {
+  public FrameName getSourceFrame() {
     return source;
   }
 
-  public GraphName getTargetFrame() {
+  public FrameName getTargetFrame() {
     return target;
   }
 

--- a/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/Transform.java
+++ b/rosjava_geometry/src/main/java/org/ros/rosjava_geometry/Transform.java
@@ -19,11 +19,10 @@ package org.ros.rosjava_geometry;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.ros.message.Time;
-import org.ros.namespace.GraphName;
 
 /**
  * A transformation in terms of translation, rotation, and scale.
- * 
+ *
  * @author damonkohler@google.com (Damon Kohler)
  * @author moesenle@google.com (Lorenz Moesenlechner)
  */
@@ -73,7 +72,7 @@ public class Transform {
 
   /**
    * Apply another {@link Transform} to this {@link Transform}.
-   * 
+   *
    * @param other
    *          the {@link Transform} to apply to this {@link Transform}
    * @return the resulting {@link Transform}
@@ -133,7 +132,7 @@ public class Transform {
     return result;
   }
 
-  public geometry_msgs.PoseStamped toPoseStampedMessage(GraphName frame, Time stamp,
+  public geometry_msgs.PoseStamped toPoseStampedMessage(FrameName frame, Time stamp,
       geometry_msgs.PoseStamped result) {
     result.getHeader().setFrameId(frame.toString());
     result.getHeader().setStamp(stamp);


### PR DESCRIPTION
http://www.ros.org/wiki/hydro/Migration#tf2.2BAC8-Migration.Removal_of_support_for_tf_prefix

They are no longer attempting to handle graph names. As it turns out, with some packages having updated and others none, rosjava causes havoc with the names. This is the case for android_tutorial_map_view where lookups to common roots fail (map-base_link) because its trying to compare the graph name resolved `/map` with the map header string `map` that got saved in the transform class internally.

I've fleshed out some rosjava_geometry2 modules that remove usage of GraphName with FrameName. The only special feature of that class is the python/cpp implementation's stripping of any leading slashes. This resolves the problems for android_tutorial_map_viewer in hydro.
