### PR TITLE
Upgrading message generation (no more ROS_PACKAGE_PATH scope).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,5 @@ catkin_rosjava_setup()
 
 catkin_package()
 
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_MAVEN_DESTINATION}/ros/rosjava_core/ 
+        DESTINATION ${CATKIN_GLOBAL_MAVEN_DESTINATION}/ros/rosjava_core)

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,14 @@ task wrapper(type: Wrapper) {
   gradleVersion = '1.5'
 }
 
+project.ext {
+  ros_maven_deployment_path = "$System.env.ROS_MAVEN_DEPLOYMENT_PATH"
+}
+
 allprojects {
   group 'ros.rosjava_core'
-  version = '0.0.0-SNAPSHOT'
+  /* version = '0.2.0-SNAPSHOT' */
+  version = '0.1.0'
 }
 
 subprojects {
@@ -37,6 +42,15 @@ subprojects {
       mavenLocal()
       maven {
         url 'https://github.com/rosjava/rosjava_mvn_repo/raw/master'
+      }
+    }
+    if ( project.ros_maven_deployment_path != 'null' && project.ros_maven_deployment_path != '' ) {
+      uploadArchives {
+        repositories {
+          mavenDeployer {
+            repository(url: 'file://' + project.ros_maven_deployment_path)
+          }
+        }
       }
     }
   }

--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,22 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rosjava_tools</build_depend>
+  <!-- message dependencies (to be generated from) -->
+  <build_depend>test_ros</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf2_msgs</build_depend>
+  <!-- common_msgs stack -->
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>shape_msgs</build_depend>
+  <build_depend>stereo_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+
+  <!-- We don't need the msg packages as run depends -->
 </package>
 

--- a/rosjava/build.gradle
+++ b/rosjava/build.gradle
@@ -16,7 +16,10 @@
 
 dependencies {
   compile project(':rosjava_bootstrap')
-  compile project(':rosjava_messages')
+  compile project(':rosjava_tf2_msgs')
+  compile project(':rosjava_common_msgs')
+  compile project(':rosjava_std_msgs')
+  compile project(':rosjava_rosgraph_msgs')
   compile project(':apache_xmlrpc_common')
   compile project(':apache_xmlrpc_server')
   compile project(':apache_xmlrpc_client')

--- a/rosjava_common_msgs/build.gradle
+++ b/rosjava_common_msgs/build.gradle
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+dependencies {
+  compile project(':rosjava_bootstrap')
+  compile project(':rosjava_std_msgs')
+}
+
+/* 
+  Should scan the package.xml of the message package we are generating 
+  and substitute that version number here. Just use the group version for now.
+  version = '0.3.0-SNAPSHOT'
+*/
+
+task generateSources(type: JavaExec) {
+  def outputDir = "${buildDir}/generated-src"
+  outputs.dir file(outputDir)
+  def List<String> argumentList = new ArrayList<String>()
+  argumentList.add(outputDir)
+  argumentList.add("actionlib_msgs")
+  argumentList.add("diagnostic_msgs")
+  argumentList.add("geometry_msgs")
+  argumentList.add("sensor_msgs")
+  argumentList.add("nav_msgs")
+  argumentList.add("shape_msgs")
+  argumentList.add("stereo_msgs")
+  argumentList.add("trajectory_msgs")
+  argumentList.add("visualization_msgs")
+  args argumentList
+  classpath = configurations.runtime
+  main = 'org.ros.internal.message.GenerateInterfaces'
+}
+
+compileJava.source generateSources.outputs.files
+
+eclipse.classpath.file {
+  withXml {
+    // TODO(damonkohler): Avoid repetition of build directory. This is
+    // necessary because Eclipse wants a project relative path.
+    it.asNode().appendNode('classpathentry', [kind: 'src', path: 'build/generated-src'])
+  }
+}

--- a/rosjava_rosgraph_msgs/build.gradle
+++ b/rosjava_rosgraph_msgs/build.gradle
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+dependencies {
+  compile project(':rosjava_bootstrap')
+  compile project(':rosjava_std_msgs')
+}
+
+/* 
+  Should scan the package.xml of the message package we are generating 
+  and substitute that version number here. Just use the group version for now.
+  version = '0.3.0-SNAPSHOT'
+*/
+
+task generateSources(type: JavaExec) {
+  def outputDir = "${buildDir}/generated-src"
+  outputs.dir file(outputDir)
+  def List<String> argumentList = new ArrayList<String>()
+  argumentList.add(outputDir)
+  argumentList.add("rosgraph_msgs")
+  args argumentList
+  classpath = configurations.runtime
+  main = 'org.ros.internal.message.GenerateInterfaces'
+}
+
+compileJava.source generateSources.outputs.files
+
+eclipse.classpath.file {
+  withXml {
+    // TODO(damonkohler): Avoid repetition of build directory. This is
+    // necessary because Eclipse wants a project relative path.
+    it.asNode().appendNode('classpathentry', [kind: 'src', path: 'build/generated-src'])
+  }
+}

--- a/rosjava_std_msgs/build.gradle
+++ b/rosjava_std_msgs/build.gradle
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+dependencies {
+  compile project(':rosjava_bootstrap')
+}
+
+/* 
+  Should scan the package.xml of the message package we are generating 
+  and substitute that version number here. Just use the group version for now.
+  version = '0.3.0-SNAPSHOT'
+*/
+
+task generateSources(type: JavaExec) {
+  def outputDir = "${buildDir}/generated-src"
+  outputs.dir file(outputDir)
+  def List<String> argumentList = new ArrayList<String>()
+  argumentList.add(outputDir)
+  argumentList.add("std_msgs")
+  args argumentList
+  classpath = configurations.runtime
+  main = 'org.ros.internal.message.GenerateInterfaces'
+}
+
+compileJava.source generateSources.outputs.files
+
+eclipse.classpath.file {
+  withXml {
+    // TODO(damonkohler): Avoid repetition of build directory. This is
+    // necessary because Eclipse wants a project relative path.
+    it.asNode().appendNode('classpathentry', [kind: 'src', path: 'build/generated-src'])
+  }
+}

--- a/rosjava_test/build.gradle
+++ b/rosjava_test/build.gradle
@@ -20,5 +20,6 @@ mainClassName = 'org.ros.RosRun'
 
 dependencies {
   compile project(':rosjava')
+  compile project(':rosjava_test_ros_msgs')
   compile 'junit:junit:4.8.2'
 }

--- a/rosjava_test_ros_msgs/build.gradle
+++ b/rosjava_test_ros_msgs/build.gradle
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+dependencies {
+  compile project(':rosjava_bootstrap')
+  compile project(':rosjava_std_msgs')
+}
+
+/* 
+  Should scan the package.xml of the message package we are generating 
+  and substitute that version number here. Just use the group version for now.
+  version = '0.3.0-SNAPSHOT'
+*/
+
+task generateSources(type: JavaExec) {
+  def outputDir = "${buildDir}/generated-src"
+  outputs.dir file(outputDir)
+  def List<String> argumentList = new ArrayList<String>()
+  argumentList.add(outputDir)
+  argumentList.add("test_ros")
+  args argumentList
+  classpath = configurations.runtime
+  main = 'org.ros.internal.message.GenerateInterfaces'
+}
+
+compileJava.source generateSources.outputs.files
+
+eclipse.classpath.file {
+  withXml {
+    // TODO(damonkohler): Avoid repetition of build directory. This is
+    // necessary because Eclipse wants a project relative path.
+    it.asNode().appendNode('classpathentry', [kind: 'src', path: 'build/generated-src'])
+  }
+}

--- a/rosjava_tf2_msgs/build.gradle
+++ b/rosjava_tf2_msgs/build.gradle
@@ -16,13 +16,22 @@
 
 dependencies {
   compile project(':rosjava_bootstrap')
+  compile project(':rosjava_common_msgs')
 }
 
+/* 
+  Should scan the package.xml of the message package we are generating 
+  and substitute that version number here. Just use the group version for now.
+  version = '0.3.0-SNAPSHOT'
+*/
 
 task generateSources(type: JavaExec) {
   def outputDir = "${buildDir}/generated-src"
   outputs.dir file(outputDir)
-  args outputDir
+  def List<String> argumentList = new ArrayList<String>()
+  argumentList.add(outputDir)
+  argumentList.add("tf2_msgs")
+  args argumentList
   classpath = configurations.runtime
   main = 'org.ros.internal.message.GenerateInterfaces'
 }

--- a/rosjava_tutorial_services/build.gradle
+++ b/rosjava_tutorial_services/build.gradle
@@ -20,4 +20,5 @@ mainClassName = 'org.ros.RosRun'
 
 dependencies {
   compile project(':rosjava')
+  compile project(':rosjava_test_ros_msgs')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,15 @@
  * the License.
  */
 
-include 'rosjava_bootstrap', 'rosjava_messages', 'apache_xmlrpc_common',
+include 'rosjava_bootstrap', 'apache_xmlrpc_common',
         'apache_xmlrpc_client', 'apache_xmlrpc_server', 'rosjava',
         'rosjava_geometry', 'rosjava_tutorial_pubsub',
         'rosjava_tutorial_services', 'rosjava_tutorial_right_hand_rule',
         'rosjava_benchmarks', 'rosjava_test', 'docs'
+
+/* Message stacks/packages */
+include 'rosjava_test_ros_msgs', 
+        'rosjava_rosgraph_msgs',
+        'rosjava_std_msgs',
+        'rosjava_common_msgs',
+        'rosjava_tf2_msgs'


### PR DESCRIPTION
**Problems**
- Difficult to define and release a fixed entity that is the rosjava_core
- If you have your own custom messages, you need to install sources anyway, not the release
  *\* And then recompile everything from the bottom (rosjava_core/rosjava_messages).
  *\* The other option is to get rosjava_core released with your msg package, but that can't avoid being a circuitous path to get a simple job done.
- Ensuring you have all the correct msg packages installed is a mysterious process that requires a human.

**The Technical Issue**
- rosjava_messages is a variable beast dependant on the current ROS_PACKAGE_PATH

**Proposed Solution - Fixed Horizon Message Generation**

Avoid relying on ROS_PACKAGE_PATH and setup a coded, fixed dependency boundaries. No source code change needed, just gradle scripting. 

**Results**
- Can generate msg packages outside rosjava_core.
- The rosjava_core release package is fixed, doesn't need obtuse workarounds like in https://github.com/rosjava/rosjava_mvn_repo/issues/3
- The package.xml's can now properly sequence builds across multiple stacks without requiring a magical rebuild of the core.
- rosjava_messages -> 
  - rosjava_rosgraph_msgs
  - rosjava_test_ros_msgs
  - rosjava_tf2_msgs
  - rosjava_common_msgs
