### PR TITLE
modified package.xml - added build dependencies for catkin

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,5 +10,11 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>genmsg</build_depend>
+  <build_depend>ros_comm</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>common_msgs</build_depend>
+  <build_depend>geometry</build_depend>
 </package>
 


### PR DESCRIPTION
Hi, i've tried to learn with new ROS build-tools recently and tried to compile rosjava_core under OS X either as 'standalone' or with Groovy-Barebones package installed. 
I think I determined that rosjava_core needs the following packages in the $ROS_PACKAGE_PATH: genmsg, ros_comm, std_msgs (part of groovy-barebones) and geometry, in order to compile without errors.

So I added these dependencies into package.xml for better catkinizaion (I guess that it should not be a problem to add rosjava_core also into https://github.com/ros/rosdistro list).

Hope this is correct.
Jarda Vitku
