### PR TITLE
Adds newNonLoopback which accepts an network interface as argument

### DIFF
--- a/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
+++ b/rosjava/src/main/java/org/ros/address/InetAddressFactory.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,13 +44,7 @@ public class InetAddressFactory {
     return address.getAddress().length == 4;
   }
 
-  private static Collection<InetAddress> getAllInetAddresses() {
-    List<NetworkInterface> networkInterfaces;
-    try {
-      networkInterfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
-    } catch (SocketException e) {
-      throw new RosRuntimeException(e);
-    }
+  private static List<InetAddress> listAllInetAddress (Collection<NetworkInterface> networkInterfaces) {
     List<InetAddress> inetAddresses = Lists.newArrayList();
     for (NetworkInterface networkInterface : networkInterfaces) {
       try {
@@ -63,14 +58,44 @@ public class InetAddressFactory {
     return inetAddresses;
   }
 
-  public static InetAddress newNonLoopback() {
-    for (InetAddress address : getAllInetAddresses()) {
+  private static Collection<InetAddress> getallInetAddresses(NetworkInterface networkInterface) {
+    List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
+    networkInterfaces.add(networkInterface);
+    return listAllInetAddress(networkInterfaces);
+  }
+
+  private static Collection<InetAddress> getAllInetAddresses() {
+    List<NetworkInterface> networkInterfaces;
+    try {
+      networkInterfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+    } catch (SocketException e) {
+      throw new RosRuntimeException(e);
+    }
+    return listAllInetAddress(networkInterfaces);
+  }
+
+  private static InetAddress filterInetAddresses (Collection<InetAddress> inetAddresses) {
+    for (InetAddress address : inetAddresses) {
       // IPv4 only for now.
       if (!address.isLoopbackAddress() && isIpv4(address)) {
         return address;
       }
     }
     throw new RosRuntimeException("No non-loopback interface found.");
+  }
+
+  public static InetAddress newNonLoopback() {
+    return filterInetAddresses(getAllInetAddresses());
+  }
+
+  public static InetAddress newNonLoopback(String networkInterfaceName) {
+    NetworkInterface networkInterface = null;
+    try {
+      networkInterface = NetworkInterface.getByName(networkInterfaceName);
+    } catch (SocketException e) {
+      throw new RosRuntimeException(e);
+    }
+    return filterInetAddresses(getallInetAddresses(networkInterface));
   }
 
   private static Collection<InetAddress> getAllInetAddressByName(String host) {


### PR DESCRIPTION
This is needed to allow the user to specify the ROS Hostname.

An example application can be: Connect to a ROS robot through a VPN. The user would like to use the tunnel interface to create the nodes and master instead of just the first available interface.

The previous API is still present so this does not break existing applications. The diff in the PR looks more invasive that what it really is. The git of it is:
- Split getAllInetAddresses in two parts: First it collects the desired interfaces and then calls a new private method with returns all the inet addresses for that interface list.
- Split newNonLoopback consists of two parts: Get the IPs and filter them. The filtering is now down in a new private method.

These modifications allowed us to avoid code duplication when creating the new public newNonLoopback method which accepts and interface.
