### PR TITLE
Documentation instruction fix for installation.

### DIFF
--- a/docs/src/main/sphinx/installing.rst
+++ b/docs/src/main/sphinx/installing.rst
@@ -27,6 +27,7 @@ you simply need to clone the github repository
 .. code-block:: bash
 
   git clone https://github.com/rosjava/rosjava_core
+  cd rosjava_core
   git checkout -b hydro origin/hydro
 
 and proceed immediately to the section on :ref:`building`.


### PR DESCRIPTION
Issue first raised on [ros answers](http://answers.ros.org/question/106276/error-in-non-ros-installation-of-rosjava/?answer=107841#post-id-107841)
