### PR TITLE
move to gradle 2.3 and latest jars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ bin
 .settings
 *.iml
 .idea
-
+local.properties

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(rosjava_core)
 
 find_package(catkin REQUIRED rosjava_build_tools)
 
-catkin_rosjava_setup(publishMavenJavaPublicationToMavenRepository installApp)
+catkin_rosjava_setup(installDist publishMavenJavaPublicationToMavenRepository)
 
 catkin_package()
 

--- a/apache_xmlrpc_client/build.gradle
+++ b/apache_xmlrpc_client/build.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-  compile project(':apache_xmlrpc_common')
-  compile 'org.apache.ws.commons:ws-commons-util:1.0.1'
+    compile project(':apache_xmlrpc_common')
+    compile 'org.apache.ws.commons:ws-commons-util:1.0.1'
 }
 

--- a/apache_xmlrpc_common/build.gradle
+++ b/apache_xmlrpc_common/build.gradle
@@ -15,7 +15,8 @@
  */
 
 dependencies {
-  compile 'org.apache.commons:com.springsource.org.apache.commons.httpclient:3.1.0'
-  compile 'org.apache.ws.commons:ws-commons-util:1.0.1'
+    //TODO change to new api: http://central.maven.org/maven2/org/apache/directory/studio/org.apache.httpcomponents.httpclient/
+    compile 'org.apache.commons:com.springsource.org.apache.commons.httpclient:3.1.0'
+    compile 'org.apache.ws.commons:ws-commons-util:1.0.1'
 }
 

--- a/apache_xmlrpc_server/build.gradle
+++ b/apache_xmlrpc_server/build.gradle
@@ -15,7 +15,6 @@
  */
 
 dependencies {
-  compile project(':apache_xmlrpc_common')
-  compile 'org.apache.commons:com.springsource.org.apache.commons.logging:1.1.1'
+    compile project(':apache_xmlrpc_common')
+    compile 'org.apache.directory.studio:org.apache.commons.logging:1.1.3'
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.2.1'
+  gradleVersion = '2.3'
 }
 
 buildscript {
@@ -25,28 +25,29 @@ buildscript {
 apply plugin: "catkin"
 
 allprojects {
-  group 'org.ros.rosjava_core'
-  version = project.catkin.pkg.version
+    apply from: "https://github.com/talregev/rosjava_bootstrap/raw/indigo/maven.gradle"
+    group 'org.ros.rosjava_core'
+    version = project.catkin.pkg.version
 }
 
 subprojects {
-  if (name != 'docs') {
-    /* 
-     * The ros plugin configures a few things:
-     * 
-     *  - local deployment repository : where it dumps the jars and packaged artifacts)
-     *  - local maven repositories    : where it finds your locally installed/built artifacts) 
-     *  - external maven repositories : where it goes looking if it can't find dependencies locally
-     * 
-     * To modify, or add repos to the default external maven repositories list, pull request against this code:
-     * 
-     *   https://github.com/rosjava/rosjava_bootstrap/blob/indigo/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosPlugin.groovy#L31
-     */
-    apply plugin: "ros-java"
-    apply plugin: "osgi"
-    apply plugin: "idea"
-    apply plugin: "eclipse"
-  }
+    if (name != 'docs') {
+        /*
+         * The ros plugin configures a few things:
+         *
+         *  - local deployment repository : where it dumps the jars and packaged artifacts)
+         *  - local maven repositories    : where it finds your locally installed/built artifacts)
+         *  - external maven repositories : where it goes looking if it can't find dependencies locally
+         *
+         * To modify, or add repos to the default external maven repositories list, pull request against this code:
+         *
+         *   https://github.com/rosjava/rosjava_bootstrap/blob/indigo/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosPlugin.groovy#L31
+         */
+        apply plugin: "ros-java"
+        apply plugin: "osgi"
+        apply plugin: "idea"
+        apply plugin: "eclipse"
+    }
 }
 
-defaultTasks 'publishMavenJavaPublicationToMavenRepository', 'installApp'
+defaultTasks 'installDist', 'publishMavenJavaPublicationToMavenRepository'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/rosjava/build.gradle
+++ b/rosjava/build.gradle
@@ -15,21 +15,21 @@
  */
 
 dependencies {
-  compile project(':apache_xmlrpc_common')
-  compile project(':apache_xmlrpc_server')
-  compile project(':apache_xmlrpc_client')
-  compile 'org.ros.rosjava_bootstrap:message_generation:[0.2,0.3)'
-  compile 'org.ros.rosjava_messages:rosjava_test_msgs:[0.2,0.3)'
-  compile 'org.ros.rosjava_messages:rosgraph_msgs:[1.10,1.11)'
-  compile 'org.ros.rosjava_messages:geometry_msgs:[1.11,1.12)'
-  compile 'org.ros.rosjava_messages:nav_msgs:[1.10,1.11)'
-  compile 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)'
-  compile 'dnsjava:dnsjava:2.1.1'
-  compile 'org.apache.commons:com.springsource.org.apache.commons.logging:1.1.1'
-  compile 'org.apache.commons:com.springsource.org.apache.commons.net:2.0.0'
-  compile 'com.google.guava:guava:12.0'
-  testCompile 'junit:junit:4.8.2'
-  testCompile 'org.mockito:mockito-all:1.8.5'
+    compile project(':apache_xmlrpc_common')
+    compile project(':apache_xmlrpc_server')
+    compile project(':apache_xmlrpc_client')
+    compile 'org.ros.rosjava_bootstrap:message_generation:[0.2,0.3)'
+    compile 'org.ros.rosjava_messages:rosjava_test_msgs:[0.2,0.3)'
+    compile 'org.ros.rosjava_messages:rosgraph_msgs:[1.10,1.11)'
+    compile 'org.ros.rosjava_messages:geometry_msgs:[1.11,1.12)'
+    compile 'org.ros.rosjava_messages:nav_msgs:[1.10,1.11)'
+    compile 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)'
+    compile 'dnsjava:dnsjava:2.1.6'
+    compile 'org.apache.directory.studio:org.apache.commons.logging:1.1.3'
+    compile 'commons-net:commons-net:3.3'
+    compile 'com.google.guava:guava:18.0'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-all:1.10.19'
 }
 
 jar {

--- a/rosjava_benchmarks/build.gradle
+++ b/rosjava_benchmarks/build.gradle
@@ -19,6 +19,6 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  compile project(':rosjava')
-  compile project(':rosjava_geometry')
+    compile project(':rosjava')
+    compile project(':rosjava_geometry')
 }

--- a/rosjava_geometry/build.gradle
+++ b/rosjava_geometry/build.gradle
@@ -15,6 +15,6 @@
  */
 
 dependencies {
-  compile project(':rosjava')
-  testCompile 'junit:junit:4.8.2'
+    compile project(':rosjava')
+    testCompile 'junit:junit:4.12'
 }

--- a/rosjava_test/build.gradle
+++ b/rosjava_test/build.gradle
@@ -19,6 +19,6 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  compile project(':rosjava')
-  compile 'junit:junit:4.8.2'
+    compile project(':rosjava')
+    compile 'junit:junit:4.12'
 }

--- a/rosjava_tutorial_pubsub/build.gradle
+++ b/rosjava_tutorial_pubsub/build.gradle
@@ -19,5 +19,5 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  compile project(':rosjava')
+    compile project(':rosjava')
 }

--- a/rosjava_tutorial_right_hand_rule/build.gradle
+++ b/rosjava_tutorial_right_hand_rule/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  compile project(':rosjava')
-  compile 'org.ros.rosjava_messages:sensor_msgs:[1.11,1.12)'
+    compile project(':rosjava')
+    compile 'org.ros.rosjava_messages:sensor_msgs:[1.11,1.12)'
 }
 

--- a/rosjava_tutorial_services/build.gradle
+++ b/rosjava_tutorial_services/build.gradle
@@ -19,5 +19,5 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  compile project(':rosjava')
+    compile project(':rosjava')
 }


### PR DESCRIPTION
- move to gradle 2.3
- update to latest jar, non breaking api from @DmitryDzz [fix](https://github.com/robot-mitya/rosjava_bootstrap/commit/f9acae776f991374428100f8193c5f3861ca9514)
- change installApp to installDist. installApp is deprecated in next gradle.
## \- update .gitignore. add local.properties
