### PR TITLE
Add new static method in Nodeconfiguration

### DIFF
--- a/rosjava/src/main/java/org/ros/node/NodeConfiguration.java
+++ b/rosjava/src/main/java/org/ros/node/NodeConfiguration.java
@@ -39,6 +39,7 @@ import org.ros.time.TimeProvider;
 import org.ros.time.WallTimeProvider;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -134,6 +135,23 @@ public class NodeConfiguration {
     configuration.setTcpRosAdvertiseAddressFactory(new PublicAdvertiseAddressFactory(host));
     configuration.setMasterUri(masterUri);
     return configuration;
+  }
+  
+  /**
+   * Creates a new {@link NodeConfiguration} for a publicly accessible {
+   * @link Node}
+   *
+   * @param masterUri
+   *          the {@link URI} for the master that the {@link Node} will register
+   *          with
+   * @return a new {@link NodeConfiguration} for a publicly accessible
+   *         {@link Node}
+   */
+  public static NodeConfiguration newPublic(URI masterUri) throws IOException {
+    java.net.Socket socket = new java.net.Socket(masterUri.getHost(), masterUri.getPort());
+    java.net.InetAddress local_network_address = socket.getLocalAddress();
+    socket.close();
+    return NodeConfiguration.newPublic(local_network_address.getHostAddress(), masterUri);
   }
 
   /**


### PR DESCRIPTION
The current existing method [newPublic(String host, URI masterUri)](https://github.com/rosjava/rosjava_core/blob/indigo/rosjava/src/main/java/org/ros/node/NodeConfiguration.java#L129-L137) requires extra configuration to connect ROS master at android app level when multiple network interfaces are available in android phone(e.g - 3g, wifi).

This new method helps to have NodeConfiguration with a proper network interface for master uri. This method has been tested with [Teleop](https://github.com/rosjava/android_apps/blob/indigo/teleop/src/main/java/com/github/rosjava/android_apps/teleop/MainActivity.java#L76-L80) for a while with android phone with 3g and wifi.
