### PR TITLE
This closes rosjava/rosjava_core#233. Adds fix for shutting down Defa…

### DIFF
--- a/rosjava/src/main/java/org/ros/concurrent/EventDispatcher.java
+++ b/rosjava/src/main/java/org/ros/concurrent/EventDispatcher.java
@@ -42,4 +42,9 @@ public class EventDispatcher<T> extends CancellableLoop {
     SignalRunnable<T> signalRunnable = events.takeFirst();
     signalRunnable.run(listener);
   }
+
+  public T getListener()
+  {
+    return listener;
+  }
 }

--- a/rosjava/src/main/java/org/ros/concurrent/ListenerGroup.java
+++ b/rosjava/src/main/java/org/ros/concurrent/ListenerGroup.java
@@ -102,6 +102,25 @@ public class ListenerGroup<T> {
   }
 
   /**
+   * Removes and cancels the {@EventDispatcher} specified by the listener
+   * from the {@link ListenerGroup}.
+   * @param listener the listener to remove
+   * @return flag indicating successful removal
+     */
+  public boolean remove(T listener)
+  {
+    for (EventDispatcher<T> eventDispatcher : eventDispatchers) {
+      if(listener.equals(eventDispatcher.getListener()))
+      {
+        eventDispatcher.cancel();
+        eventDispatchers.remove(eventDispatcher);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * @return the number of listeners in the group
    */
   public int size() {
@@ -151,5 +170,6 @@ public class ListenerGroup<T> {
     for (EventDispatcher<T> eventDispatcher : eventDispatchers) {
       eventDispatcher.cancel();
     }
+    eventDispatchers.clear();
   }
 }

--- a/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
+++ b/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
@@ -493,6 +493,11 @@ public class DefaultNode implements ConnectedNode {
     });
   }
 
+  @Override
+  public void removeListeners() {
+    nodeListeners.shutdown();
+  }
+
   /**
    * SignalRunnable all {@link NodeListener}s that the {@link Node} has started.
    * <p>

--- a/rosjava/src/main/java/org/ros/node/DefaultNodeMainExecutor.java
+++ b/rosjava/src/main/java/org/ros/node/DefaultNodeMainExecutor.java
@@ -213,6 +213,7 @@ public class DefaultNodeMainExecutor implements NodeMainExecutor {
    *          the {@link Node} to unregister
    */
   private void unregisterNode(Node node) {
+    node.removeListeners();
     connectedNodes.get(node.getName()).remove(node);
     nodeMains.remove(node);
   }

--- a/rosjava/src/main/java/org/ros/node/Node.java
+++ b/rosjava/src/main/java/org/ros/node/Node.java
@@ -126,4 +126,10 @@ public interface Node {
    * Shut the node down.
    */
   void shutdown();
+
+  /**
+   * Stops and Clears node listeners.
+   */
+
+  void removeListeners();
 }


### PR DESCRIPTION
…ultNodeMainExecutor ListenerGroup to prevent leak in android when activities are destroyed. Added ability to remove listener from ListenerGroup to fix android_core issue #254.