### PR TITLE
Fix: avoid exceptions on node shutdown

### DIFF
--- a/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
+++ b/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
@@ -39,8 +39,6 @@ import org.ros.internal.node.service.ServiceDeclaration;
 import org.ros.internal.node.service.ServiceFactory;
 import org.ros.internal.node.service.ServiceIdentifier;
 import org.ros.internal.node.service.ServiceManager;
-import org.ros.internal.node.topic.DefaultPublisher;
-import org.ros.internal.node.topic.DefaultSubscriber;
 import org.ros.internal.node.topic.PublisherFactory;
 import org.ros.internal.node.topic.SubscriberFactory;
 import org.ros.internal.node.topic.TopicDeclaration;
@@ -405,6 +403,7 @@ public class DefaultNode implements ConnectedNode {
     // NOTE(damonkohler): We don't want to raise potentially spurious
     // exceptions during shutdown that would interrupt the process. This is
     // simply best effort cleanup.
+    slaveServer.shutdown();
     topicParticipantManager.shutdown();
     for (ServiceServer<?, ?> serviceServer : serviceManager.getServers()) {
       try {

--- a/rosjava_helpers/src/main/java/org/ros/helpers/ParameterLoaderNode.java
+++ b/rosjava_helpers/src/main/java/org/ros/helpers/ParameterLoaderNode.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class ParameterLoaderNode extends AbstractNodeMain {
 
     public static final String NODE_NAME = "parameter_loader";
-    private final List<LoadedResource> params = new ArrayList<>();
+    private final List<LoadedResource> params = new ArrayList<LoadedResource>();
     private Log log;
 
     /**
@@ -57,6 +57,7 @@ public class ParameterLoaderNode extends AbstractNodeMain {
         this.params.add(new LoadedResource((new Yaml()).load(ymlInputStream), namespace));
     }
 
+    @SuppressWarnings("unchecked")
     private void addParams(ParameterTree parameterTree, String namespace, Map<String, Object> params) {
         for (Map.Entry<String, Object> e : params.entrySet()) {
             String fullKeyName = namespace + "/" + e.getKey();


### PR DESCRIPTION
This PR fixes [part of] #241 .
Now no exceptions are thrown when a node is shut down in the case that the node is connected to a topic that has subscribers. I will close #241 and open another one to track the exception when the topic (only the topic, not the node) is shut down once this is merged. 

I also corrected some nits for ParameterLoader.