### PR TITLE
Fix remapping member variable not set if argument is not null

### DIFF
--- a/rosjava/src/main/java/org/ros/node/NativeNodeMain.java
+++ b/rosjava/src/main/java/org/ros/node/NativeNodeMain.java
@@ -53,6 +53,8 @@ public abstract class NativeNodeMain extends AbstractNodeMain {
     // if no remapping is needed, create an empty array
     if (remappings == null) {
       remappingArguments = new String[0];
+    } else {
+      remappingArguments = remappings;
     }
     
     log.info("Trying to load native library '" + libName + "'...");


### PR DESCRIPTION
In the constructor of the `NativeNodeMain` that takes a string array as argument for remapping, the remapping member variable is not set if the argument is not null.
This PR fixes this issue.