### PR TITLE
simtime: use time=0 by default

### DIFF
--- a/rosjava/src/main/java/org/ros/time/ClockTopicTimeProvider.java
+++ b/rosjava/src/main/java/org/ros/time/ClockTopicTimeProvider.java
@@ -57,7 +57,12 @@ public class ClockTopicTimeProvider implements TimeProvider {
 
   @Override
   public Time getCurrentTime() {
-    Preconditions.checkNotNull(clock);
+    // When using simulation time, the ROS Time API will return time=0 until it has received a
+    // message from the /clock topic.
+    if (clock == null) {
+      return new Time();
+    }
+
     synchronized (mutex) {
       return new Time(clock.getClock());
     }


### PR DESCRIPTION
This is the behaviour documented here:
http://wiki.ros.org/Clock#Using_Simulation_Time_from_the_.2BAC8-clock_Topic

    If the /use_sim_time parameter is set, the ROS Time API will return
    time=0 until it has received a value from the /clock topic. Then,
    the time will only be updated on receipt of a message from the
    /clock topic, and will stay constant between updates.

This resolves a NullPointerException when a node logs from its onStart
method and use_sim_time is true.