### PR TITLE
Add Bazel build files for the tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ bin
 .settings
 *.iml
 .idea
-
+bazel-*

--- a/3rdparty/jvm/com/google/code/findbugs/BUILD
+++ b/3rdparty/jvm/com/google/code/findbugs/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "jsr305",
+    exports = [
+        "//external:jar/com/google/code/findbugs/jsr305"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/com/google/guava/BUILD
+++ b/3rdparty/jvm/com/google/guava/BUILD
@@ -1,0 +1,15 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "guava",
+    exports = [
+        "//external:jar/com/google/guava/guava"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/google/code/findbugs:jsr305"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/commons_pool/BUILD
+++ b/3rdparty/jvm/commons_pool/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "commons_pool",
+    exports = [
+        "//external:jar/commons_pool/commons_pool"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/dnsjava/BUILD
+++ b/3rdparty/jvm/dnsjava/BUILD
@@ -1,0 +1,15 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "dnsjava",
+    exports = [
+        "//external:jar/dnsjava/dnsjava"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/junit:junit"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/io/netty/BUILD
+++ b/3rdparty/jvm/io/netty/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "netty",
+    exports = [
+        "//external:jar/io/netty/netty"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/junit/BUILD
+++ b/3rdparty/jvm/junit/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "junit",
+    exports = [
+        "//external:jar/junit/junit"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/apache/commons/BUILD
+++ b/3rdparty/jvm/org/apache/commons/BUILD
@@ -1,0 +1,76 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "com_springsource_org_apache_commons_codec",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_codec"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "com_springsource_org_apache_commons_httpclient",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_httpclient"
+    ],
+    runtime_deps = [
+        ":com_springsource_org_apache_commons_codec",
+        ":com_springsource_org_apache_commons_logging"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "com_springsource_org_apache_commons_io",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_io"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "com_springsource_org_apache_commons_lang",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_lang"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "com_springsource_org_apache_commons_logging",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_logging"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "com_springsource_org_apache_commons_net",
+    exports = [
+        "//external:jar/org/apache/commons/com_springsource_org_apache_commons_net"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/apache/ws/commons/BUILD
+++ b/3rdparty/jvm/org/apache/ws/commons/BUILD
@@ -1,0 +1,16 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "ws_commons_util",
+    exports = [
+        "//external:jar/org/apache/ws/commons/ws_commons_util"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/junit:junit",
+        "//3rdparty/jvm/xml_apis:xml_apis"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/mockito/BUILD
+++ b/3rdparty/jvm/org/mockito/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "mockito_all",
+    exports = [
+        "//external:jar/org/mockito/mockito_all"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/ros/rosjava_bootstrap/BUILD
+++ b/3rdparty/jvm/org/ros/rosjava_bootstrap/BUILD
@@ -1,0 +1,33 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "gradle_plugins",
+    exports = [
+        "//external:jar/org/ros/rosjava_bootstrap/gradle_plugins"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "message_generation",
+    exports = [
+        "//external:jar/org/ros/rosjava_bootstrap/message_generation"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/com/google/guava:guava",
+        "//3rdparty/jvm/commons_pool:commons_pool",
+        "//3rdparty/jvm/io/netty:netty",
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_codec",
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_io",
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_lang",
+        ":gradle_plugins"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/org/ros/rosjava_messages/BUILD
+++ b/3rdparty/jvm/org/ros/rosjava_messages/BUILD
@@ -1,0 +1,31 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "rosgraph_msgs",
+    exports = [
+        "//external:jar/org/ros/rosjava_messages/rosgraph_msgs"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/ros/rosjava_bootstrap:message_generation",
+        ":std_msgs"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+
+
+java_library(
+    name = "std_msgs",
+    exports = [
+        "//external:jar/org/ros/rosjava_messages/std_msgs"
+    ],
+    runtime_deps = [
+        "//3rdparty/jvm/org/ros/rosjava_bootstrap:message_generation"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/jvm/xml_apis/BUILD
+++ b/3rdparty/jvm/xml_apis/BUILD
@@ -1,0 +1,12 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+java_library(
+    name = "xml_apis",
+    exports = [
+        "//external:jar/xml_apis/xml_apis"
+    ],
+    visibility = [
+        "//visibility:public"
+    ]
+)
+
+

--- a/3rdparty/workspace.bzl
+++ b/3rdparty/workspace.bzl
@@ -1,0 +1,37 @@
+# Do not edit. bazel-deps autogenerates this file from dependencies.yaml.
+
+def declare_maven(hash):
+    native.maven_jar(
+        name = hash["name"],
+        artifact = hash["artifact"],
+        sha1 = hash["sha1"],
+        repository = hash["repository"]
+    )
+    native.bind(
+        name = hash["bind"],
+        actual = hash["actual"]
+    )
+
+def maven_dependencies(callback = declare_maven):
+    callback({"artifact": "com.google.code.findbugs:jsr305:1.3.9", "lang": "java", "sha1": "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf", "repository": "https://jcenter.bintray.com/", "name": "com_google_code_findbugs_jsr305", "actual": "@com_google_code_findbugs_jsr305//jar", "bind": "jar/com/google/code/findbugs/jsr305"})
+    callback({"artifact": "com.google.guava:guava:12.0", "lang": "java", "sha1": "5bc66dd95b79db1e437eb08adba124a3e4088dc0", "repository": "https://jcenter.bintray.com/", "name": "com_google_guava_guava", "actual": "@com_google_guava_guava//jar", "bind": "jar/com/google/guava/guava"})
+    callback({"artifact": "commons-pool:commons-pool:1.6", "lang": "java", "sha1": "4572d589699f09d866a226a14b7f4323c6d8f040", "repository": "https://jcenter.bintray.com/", "name": "commons_pool_commons_pool", "actual": "@commons_pool_commons_pool//jar", "bind": "jar/commons_pool/commons_pool"})
+    callback({"artifact": "dnsjava:dnsjava:2.1.1", "lang": "java", "sha1": "5708df81cf6dbff545695f0be6380b7bbc85accc", "repository": "https://jcenter.bintray.com/", "name": "dnsjava_dnsjava", "actual": "@dnsjava_dnsjava//jar", "bind": "jar/dnsjava/dnsjava"})
+    callback({"artifact": "io.netty:netty:3.5.13.Final", "lang": "java", "sha1": "389edea561995909d5df3e70fb2c49954ac79a54", "repository": "https://jcenter.bintray.com/", "name": "io_netty_netty", "actual": "@io_netty_netty//jar", "bind": "jar/io/netty/netty"})
+# duplicates in junit:junit fixed to 4.8.2
+# - org.apache.ws.commons:ws-commons-util:1.0.1 wanted version 3.8.1
+# - dnsjava:dnsjava:2.1.1 wanted version 3.8.2
+    callback({"artifact": "junit:junit:4.8.2", "lang": "java", "sha1": "c94f54227b08100974c36170dcb53329435fe5ad", "repository": "https://jcenter.bintray.com/", "name": "junit_junit", "actual": "@junit_junit//jar", "bind": "jar/junit/junit"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.codec:1.3.0", "lang": "java", "sha1": "f8690570eb0913d750262bb4223eed30b0d619ed", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_codec", "actual": "@org_apache_commons_com_springsource_org_apache_commons_codec//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_codec"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.httpclient:3.1.0", "lang": "java", "sha1": "c493a925a091ac3d8f449d9265fe12482dabb2a7", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_httpclient", "actual": "@org_apache_commons_com_springsource_org_apache_commons_httpclient//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_httpclient"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.io:1.4.0", "lang": "java", "sha1": "51097cd000ec88214ff181c9f059947de1cf4a35", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_io", "actual": "@org_apache_commons_com_springsource_org_apache_commons_io//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_io"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.lang:2.4.0", "lang": "java", "sha1": "686e3713650c8e3a5d98723b4d3e239586bf9822", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_lang", "actual": "@org_apache_commons_com_springsource_org_apache_commons_lang//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_lang"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.logging:1.1.1", "lang": "java", "sha1": "7657caf2c78e1d79c74d36f2ae128a115f7cc180", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_logging", "actual": "@org_apache_commons_com_springsource_org_apache_commons_logging//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_logging"})
+    callback({"artifact": "org.apache.commons:com.springsource.org.apache.commons.net:2.0.0", "lang": "java", "sha1": "03e78766072ff5a5cf3f5431d973c430c94ec612", "repository": "https://jcenter.bintray.com/", "name": "org_apache_commons_com_springsource_org_apache_commons_net", "actual": "@org_apache_commons_com_springsource_org_apache_commons_net//jar", "bind": "jar/org/apache/commons/com_springsource_org_apache_commons_net"})
+    callback({"artifact": "org.apache.ws.commons:ws-commons-util:1.0.1", "lang": "java", "sha1": "126e80ff798fece634bc94e61f8be8a8da00be60", "repository": "https://jcenter.bintray.com/", "name": "org_apache_ws_commons_ws_commons_util", "actual": "@org_apache_ws_commons_ws_commons_util//jar", "bind": "jar/org/apache/ws/commons/ws_commons_util"})
+    callback({"artifact": "org.mockito:mockito-all:1.8.5", "lang": "java", "sha1": "a927d8ae3b8d22eb745a74f94e59ce3882f2b524", "repository": "https://jcenter.bintray.com/", "name": "org_mockito_mockito_all", "actual": "@org_mockito_mockito_all//jar", "bind": "jar/org/mockito/mockito_all"})
+    callback({"artifact": "org.ros.rosjava_bootstrap:gradle_plugins:0.3.0", "lang": "java", "sha1": "9915d897f3b5049e99b268068978a1bca0ae7b5d", "repository": "https://github.com/rosjava/rosjava_mvn_repo/raw/master", "name": "org_ros_rosjava_bootstrap_gradle_plugins", "actual": "@org_ros_rosjava_bootstrap_gradle_plugins//jar", "bind": "jar/org/ros/rosjava_bootstrap/gradle_plugins"})
+    callback({"artifact": "org.ros.rosjava_bootstrap:message_generation:0.3.0", "lang": "java", "sha1": "5141e448f0ea6a2d6f539219d4fc9b296ff07ca4", "repository": "https://github.com/rosjava/rosjava_mvn_repo/raw/master", "name": "org_ros_rosjava_bootstrap_message_generation", "actual": "@org_ros_rosjava_bootstrap_message_generation//jar", "bind": "jar/org/ros/rosjava_bootstrap/message_generation"})
+    callback({"artifact": "org.ros.rosjava_messages:rosgraph_msgs:1.11.2", "lang": "java", "sha1": "adb731dd5181976b23c217872f61c724a3af70fe", "repository": "https://github.com/rosjava/rosjava_mvn_repo/raw/master", "name": "org_ros_rosjava_messages_rosgraph_msgs", "actual": "@org_ros_rosjava_messages_rosgraph_msgs//jar", "bind": "jar/org/ros/rosjava_messages/rosgraph_msgs"})
+    callback({"artifact": "org.ros.rosjava_messages:std_msgs:0.5.11", "lang": "java", "sha1": "a0191f0506dfecfc471eb199a119691717801c0e", "repository": "https://github.com/rosjava/rosjava_mvn_repo/raw/master", "name": "org_ros_rosjava_messages_std_msgs", "actual": "@org_ros_rosjava_messages_std_msgs//jar", "bind": "jar/org/ros/rosjava_messages/std_msgs"})
+    callback({"artifact": "xml-apis:xml-apis:1.0.b2", "lang": "java", "sha1": "3136ca936f64c9d68529f048c2618bd356bf85c9", "repository": "https://jcenter.bintray.com/", "name": "xml_apis_xml_apis", "actual": "@xml_apis_xml_apis//jar", "bind": "jar/xml_apis/xml_apis"})

--- a/README.md
+++ b/README.md
@@ -60,3 +60,44 @@ code. The CLA protects you and us.
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Damon will respond on either github
 or email to confirm.
+
+### Building with Bazel ###
+
+To build this project with Bazel, simply run:
+
+```
+bazel build //...
+```
+
+To depend on `rosjava_core` from another project, you'll need to use
+[bazel-deps](https://github.com/johnynek/bazel-deps).
+
+1. Start by copying (or merging) [dependencies.yaml][dependencies.yaml] in to
+   your project.
+1. Follow the instructions in that file to generate the BUILD files inside your
+   project.
+1. Add the following lines to your WORKSPACE file:
+
+```
+load("//3rdparty:workspace.bzl", "maven_dependencies")
+
+maven_dependencies()
+
+git_repository(
+    name = "com_github_rosjava_rosjava_core",
+    remote = "https://github.com/rosjava/rosjava_core",
+    commit = "HEAD",
+)
+
+load("@com_github_rosjava_rosjava_core//bazel:repositories.bzl", "rosjava_repositories")
+
+rosjava_repositories()
+```
+
+*You may want to use `http_archive` instead of `git_repository` for the reasons
+described in the [Bazel docs][git-repository-docs].*
+
+[git-repository-docs]: https://docs.bazel.build/versions/master/be/workspace.html#git_repository
+
+You can now depend on rosjava targets (eg
+`@com_github_rosjava_rosjava_core//rosjava`) as required by your application.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ maven_dependencies()
 
 git_repository(
     name = "com_github_rosjava_rosjava_core",
-    remote = "https://github.com/rosjava/rosjava_core",
-    commit = "HEAD",
+    commit = "{insert commit SHA for HEAD}",
+    remote = "https://github.com/rosjava/rosjava_core.git",
 )
 
 load("@com_github_rosjava_rosjava_core//bazel:repositories.bzl", "rosjava_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,9 @@
+workspace(name = "com_github_rosjava_rosjava_core")
+
+load("//3rdparty:workspace.bzl", "maven_dependencies")
+
+maven_dependencies()
+
+load("//bazel:repositories.bzl", "rosjava_repositories")
+
+rosjava_repositories()

--- a/apache_xmlrpc_client/BUILD.bazel
+++ b/apache_xmlrpc_client/BUILD.bazel
@@ -1,0 +1,15 @@
+java_library(
+    name = "apache_xmlrpc_client",
+    srcs = glob([
+        "src/main/**/*.java",
+    ]),
+    resources = glob([
+        "src/main/resources/**",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_httpclient",
+        "//3rdparty/jvm/org/apache/ws/commons:ws_commons_util",
+        "//apache_xmlrpc_common",
+    ],
+)

--- a/apache_xmlrpc_common/BUILD.bazel
+++ b/apache_xmlrpc_common/BUILD.bazel
@@ -1,0 +1,11 @@
+java_library(
+    name = "apache_xmlrpc_common",
+    srcs = glob([
+        "src/main/**/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_httpclient",
+        "//3rdparty/jvm/org/apache/ws/commons:ws_commons_util",
+    ],
+)

--- a/apache_xmlrpc_server/BUILD.bazel
+++ b/apache_xmlrpc_server/BUILD.bazel
@@ -1,0 +1,11 @@
+java_library(
+    name = "apache_xmlrpc_server",
+    srcs = glob([
+        "src/main/**/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_logging",
+        "//apache_xmlrpc_common",
+    ],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -4,14 +4,12 @@ Maven dependencies must be added to the workspace with bazel-deps.
 """
 
 def rosjava_repositories():
-  # DO NOT SUBMIT: update this after the pull request has been merged:
-  # https://github.com/rosjava/rosjava_bootstrap/pull/66
   _maybe(native.http_archive,
       name = "com_github_rosjava_rosjava_bootstrap",
-      sha256 = "56e52765c47b8f210f423cca49238beef50ff25310439c809717cb607b5a2271",
-      strip_prefix = "rosjava_bootstrap-b4dd3fc4adbe8e3613b0ecddcb8b2ea3fda6f5e2",
+      sha256 = "3c59776a8c6e22232d07f29a686c0e5f401812ec27f59405711657d54a792c08",
+      strip_prefix = "rosjava_bootstrap-62f865dbe8a7830b21e054dc2a5ac7d2edc6eafe",
       urls = [
-          "https://github.com/rosjava/rosjava_bootstrap/archive/b4dd3fc4adbe8e3613b0ecddcb8b2ea3fda6f5e2.tar.gz",
+          "https://github.com/rosjava/rosjava_bootstrap/archive/62f865dbe8a7830b21e054dc2a5ac7d2edc6eafe.tar.gz",
       ],
   )
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,21 @@
+"""External dependencies for rosjava_core, excluding Maven dependencies.
+
+Maven dependencies must be added to the workspace with bazel-deps.
+"""
+
+def rosjava_repositories():
+  # DO NOT SUBMIT: update this after the pull request has been merged:
+  # https://github.com/rosjava/rosjava_bootstrap/pull/66
+  _maybe(native.http_archive,
+      name = "com_github_rosjava_rosjava_bootstrap",
+      sha256 = "56e52765c47b8f210f423cca49238beef50ff25310439c809717cb607b5a2271",
+      strip_prefix = "rosjava_bootstrap-b4dd3fc4adbe8e3613b0ecddcb8b2ea3fda6f5e2",
+      urls = [
+          "https://github.com/rosjava/rosjava_bootstrap/archive/b4dd3fc4adbe8e3613b0ecddcb8b2ea3fda6f5e2.tar.gz",
+      ],
+  )
+
+
+def _maybe(repo_rule, name, **kwargs):
+  if name not in native.existing_rules():
+    repo_rule(name=name, **kwargs)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,80 @@
+# If you edit this file, follow these instructions to generate the output
+# files:
+#
+# cd ..
+# git clone https://github.com/johnynek/bazel-deps
+# cd bazel-deps
+# bazel build src/scala/com/github/johnynek/bazel_deps:parseproject_deploy.jar
+# cd ../rosjava_core
+# ../bazel-deps/gen_maven_deps.sh generate -r $PWD -s 3rdparty/workspace.bzl -d dependencies.yaml
+
+options:
+  languages: [ "java" ]
+  resolvers:
+    - id: "jcenter"
+      type: "default"
+      url: https://jcenter.bintray.com/
+    - id: "rosjava_mvn_repo"
+      type: "default"
+      url: https://github.com/rosjava/rosjava_mvn_repo/raw/master
+  resolverCache: bazel_output_base
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+  buildHeader:
+    - "# Do not edit. bazel-deps autogenerates this file from dependencies.yaml."
+
+dependencies:
+  commons-pool:
+    commons-pool:
+      lang: java
+      version: "1.6"
+  com.google.guava:
+    guava:
+      lang: java
+      version: "12.0"
+  dnsjava:
+    dnsjava:
+      lang: java
+      version: "2.1.1"
+  io.netty:
+    netty:
+      lang: java
+      version: "3.5.13.Final"
+  junit:
+    junit:
+      lang: java
+      version: "4.8.2"
+  org.apache.commons:
+    com.springsource.org.apache.commons.codec:
+      lang: java
+      version: "1.3.0"
+    com.springsource.org.apache.commons.httpclient:
+      lang: java
+      version: "3.1.0"
+    com.springsource.org.apache.commons.io:
+      lang: java
+      version: "1.4.0"
+    com.springsource.org.apache.commons.lang:
+      lang: java
+      version: "2.4.0"
+    com.springsource.org.apache.commons.logging:
+      lang: java
+      version: "1.1.1"
+    com.springsource.org.apache.commons.net:
+      lang: java
+      version: "2.0.0"
+  org.apache.ws.commons:
+    ws-commons-util:
+      lang: java
+      version: "1.0.1"
+  org.mockito:
+    mockito-all:
+      lang: java
+      version: "1.8.5"
+  org.ros.rosjava_messages:
+    rosgraph_msgs:
+      lang: java
+      version: "1.11.2"
+    std_msgs:
+      lang: java
+      version: "0.5.11"

--- a/rosjava/BUILD.bazel
+++ b/rosjava/BUILD.bazel
@@ -1,0 +1,20 @@
+java_library(
+    name = "rosjava",
+    srcs = glob([
+        "src/main/**/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//3rdparty/jvm/com/google/guava",
+        "//3rdparty/jvm/dnsjava",
+        "//3rdparty/jvm/io/netty",
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_logging",
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_net",
+        "//3rdparty/jvm/org/ros/rosjava_messages:rosgraph_msgs",
+        "//3rdparty/jvm/org/ros/rosjava_messages:std_msgs",
+        "//apache_xmlrpc_client",
+        "//apache_xmlrpc_common",
+        "//apache_xmlrpc_server",
+        "@com_github_rosjava_rosjava_bootstrap//message_generation",
+    ],
+)

--- a/rosjava_tutorial_pubsub/BUILD.bazel
+++ b/rosjava_tutorial_pubsub/BUILD.bazel
@@ -1,0 +1,13 @@
+java_binary(
+    name = "rosjava_tutorial_pubsub",
+    srcs = glob([
+        "src/main/**/*.java",
+    ]),
+    main_class = "org.ros.RosRun",
+    deps = [
+        "//3rdparty/jvm/org/apache/commons:com_springsource_org_apache_commons_logging",
+        "//3rdparty/jvm/org/ros/rosjava_messages:std_msgs",
+        "//rosjava",
+        "@com_github_rosjava_rosjava_bootstrap//message_generation",
+    ],
+)


### PR DESCRIPTION
This also allows other Bazel projects to include rosjava_core as an
external repository, as instructed in README.md.

This uses https://github.com/johnynek/bazel-deps to describe the Maven
dependencies. As a result, 3rdparty/ contains autogenerated files, and
the other files contain a hand-written description of the BUILD.