### PR TITLE
fixing an npe in the RetryingExecuterService caused by a race condition

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>rosjava_core</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>
     An implementation of ROS in pure-Java with Android support.
   </description>

--- a/rosjava/src/main/java/org/ros/concurrent/RetryingExecutorService.java
+++ b/rosjava/src/main/java/org/ros/concurrent/RetryingExecutorService.java
@@ -63,7 +63,10 @@ public class RetryingExecutorService {
     @Override
     public void loop() throws InterruptedException {
       Future<Boolean> future = completionService.take();
-      final Callable<Boolean> callable = callables.remove(future);
+      final Callable<Boolean> callable;
+      synchronized (mutex) {
+        callable = callables.remove(future);
+      }
       boolean retry;
       try {
         retry = future.get();


### PR DESCRIPTION
This will resolve the following exception 
```
exception from thread: pool-1-thread-5
java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.ros.concurrent.RetryingExecutorService$RetryLoop.loop(RetryingExecutorService.java:84)
	at org.ros.concurrent.CancellableLoop.run(CancellableLoop.java:56)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
The version number is incremented so we can distinguish this build from that of regular rosjava. 