### PR TITLE
Use new http_archive rule for Bazel deps

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -3,8 +3,10 @@
 Maven dependencies must be added to the workspace with bazel-deps.
 """
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 def rosjava_repositories():
-  _maybe(native.http_archive,
+  _maybe(http_archive,
       name = "com_googlesource_gerrit_bazlets",
       sha256 = "cdd1a90733cdb71ac4fb86aa6027d3fcad275fe74781175f8437a9c86a0db149",
       strip_prefix = "bazlets-4459b9706a6eedb8453a98d4434fb3bc4db84211",
@@ -13,7 +15,7 @@ def rosjava_repositories():
       ],
   )
 
-  _maybe(native.http_archive,
+  _maybe(http_archive,
       name = "com_github_rosjava_rosjava_bootstrap",
       sha256 = "3c59776a8c6e22232d07f29a686c0e5f401812ec27f59405711657d54a792c08",
       strip_prefix = "rosjava_bootstrap-62f865dbe8a7830b21e054dc2a5ac7d2edc6eafe",


### PR DESCRIPTION
This replaces the older native rules, which will be disabled by default
in an upcoming release.