### PR TITLE
Adding TCP-NO-DELAY transport hint

### DIFF
--- a/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
+++ b/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
@@ -65,6 +65,7 @@ import org.ros.node.topic.DefaultPublisherListener;
 import org.ros.node.topic.DefaultSubscriberListener;
 import org.ros.node.topic.Publisher;
 import org.ros.node.topic.Subscriber;
+import org.ros.node.topic.TransportHints;
 import org.ros.time.ClockTopicTimeProvider;
 import org.ros.time.TimeProvider;
 
@@ -283,7 +284,7 @@ public class DefaultNode implements ConnectedNode {
     TopicDescription topicDescription =
         nodeConfiguration.getTopicDescriptionFactory().newFromType(messageType);
     TopicDeclaration topicDeclaration =
-        TopicDeclaration.newFromTopicName(resolvedTopicName, topicDescription);
+        TopicDeclaration.newFromTopicName(resolvedTopicName, topicDescription, null);
     org.ros.message.MessageSerializer<T> serializer = newMessageSerializer(messageType);
     return publisherFactory.newOrExisting(topicDeclaration, serializer);
   }
@@ -295,11 +296,16 @@ public class DefaultNode implements ConnectedNode {
 
   @Override
   public <T> Subscriber<T> newSubscriber(GraphName topicName, String messageType) {
+    return newSubscriber(topicName, messageType, null);
+  }
+
+  @Override
+  public <T> Subscriber<T> newSubscriber(GraphName topicName, String messageType, TransportHints transportHints) {
     GraphName resolvedTopicName = resolveName(topicName);
     TopicDescription topicDescription =
         nodeConfiguration.getTopicDescriptionFactory().newFromType(messageType);
     TopicDeclaration topicDeclaration =
-        TopicDeclaration.newFromTopicName(resolvedTopicName, topicDescription);
+        TopicDeclaration.newFromTopicName(resolvedTopicName, topicDescription, transportHints);
     MessageDeserializer<T> deserializer = newMessageDeserializer(messageType);
     Subscriber<T> subscriber = subscriberFactory.newOrExisting(topicDeclaration, deserializer);
     return subscriber;
@@ -307,7 +313,12 @@ public class DefaultNode implements ConnectedNode {
 
   @Override
   public <T> Subscriber<T> newSubscriber(String topicName, String messageType) {
-    return newSubscriber(GraphName.of(topicName), messageType);
+    return newSubscriber(GraphName.of(topicName), messageType, null);
+  }
+
+  @Override
+  public <T> Subscriber<T> newSubscriber(String topicName, String messageType, TransportHints transportHints) {
+    return newSubscriber(GraphName.of(topicName), messageType, transportHints);
   }
 
   @Override

--- a/rosjava/src/main/java/org/ros/internal/node/response/TopicListResultFactory.java
+++ b/rosjava/src/main/java/org/ros/internal/node/response/TopicListResultFactory.java
@@ -43,7 +43,7 @@ public class TopicListResultFactory implements ResultFactory<List<TopicDeclarati
       String name = (String) ((Object[]) topic)[0];
       String type = (String) ((Object[]) topic)[1];
       descriptions.add(TopicDeclaration.newFromTopicName(GraphName.of(name), new TopicDescription(type, null,
-          null)));
+          null), null));
     }
     return descriptions;
   }

--- a/rosjava/src/main/java/org/ros/internal/transport/tcp/TcpServerHandshakeHandler.java
+++ b/rosjava/src/main/java/org/ros/internal/transport/tcp/TcpServerHandshakeHandler.java
@@ -96,6 +96,10 @@ public class TcpServerHandshakeHandler extends SimpleChannelHandler {
     DefaultPublisher<?> publisher = topicParticipantManager.getPublisher(topicName);
     ChannelBuffer outgoingBuffer = publisher.finishHandshake(incomingConnectionHeader);
     Channel channel = ctx.getChannel();
+    if (incomingConnectionHeader.hasField(ConnectionHeaderFields.TCP_NODELAY)) {
+      boolean tcpNoDelay = "1".equals(incomingConnectionHeader.getField(ConnectionHeaderFields.TCP_NODELAY));
+      channel.getConfig().setOption("tcpNoDelay", tcpNoDelay);
+    }
     ChannelFuture future = channel.write(outgoingBuffer).await();
     if (!future.isSuccess()) {
       throw new RosRuntimeException(future.getCause());

--- a/rosjava/src/main/java/org/ros/node/ConnectedNode.java
+++ b/rosjava/src/main/java/org/ros/node/ConnectedNode.java
@@ -26,6 +26,7 @@ import org.ros.node.service.ServiceResponseBuilder;
 import org.ros.node.service.ServiceServer;
 import org.ros.node.topic.Publisher;
 import org.ros.node.topic.Subscriber;
+import org.ros.node.topic.TransportHints;
 
 import java.net.URI;
 
@@ -83,9 +84,27 @@ public interface ConnectedNode extends Node {
   <T> Subscriber<T> newSubscriber(GraphName topicName, String messageType);
 
   /**
+   * @param <T>
+   *          the message type to create the {@link Subscriber} for
+   * @param topicName
+   *          the topic name to be subscribed to, this will be auto resolved
+   * @param messageType
+   *          the message data type (e.g. "std_msgs/String")
+   * @param transportHints
+   *          the transport hints
+   * @return a {@link Subscriber} for the specified topic
+   */
+  <T> Subscriber<T> newSubscriber(GraphName topicName, String messageType, TransportHints transportHints);
+
+  /**
    * @see #newSubscriber(GraphName, String)
    */
   <T> Subscriber<T> newSubscriber(String topicName, String messageType);
+
+  /**
+   * @see #newSubscriber(GraphName, String, TransportHints)
+   */
+  <T> Subscriber<T> newSubscriber(String topicName, String messageType, TransportHints transportHints);
 
   /**
    * Create a new {@link ServiceServer}.

--- a/rosjava/src/main/java/org/ros/node/topic/TransportHints.java
+++ b/rosjava/src/main/java/org/ros/node/topic/TransportHints.java
@@ -1,0 +1,43 @@
+package org.ros.node.topic;
+
+import java.util.Map;
+
+import org.ros.internal.transport.ConnectionHeaderFields;
+import org.ros.node.ConnectedNode;
+
+import com.google.common.collect.Maps;
+
+
+/**
+ * Provides a way of specifying network transport hints to
+ * {@link ConnectedNode#newSubscriber(String, String)} and
+ * {@link ConnectedNode#newSubscriber(org.ros.namespace.GraphName, String)}.
+ *
+ * @author stefan.glaser@hs-offenburg.de (Stefan Glaser)
+ */
+public class TransportHints {
+
+  Map<String, String> options;
+
+ public TransportHints() {
+   this.options = Maps.newConcurrentMap();
+  }
+
+  public TransportHints(boolean tcpNoDelay) {
+    tcpNoDelay(tcpNoDelay);
+  }
+
+  public TransportHints tcpNoDelay(boolean nodelay) {
+    options.put(ConnectionHeaderFields.TCP_NODELAY, nodelay ? "1" : "0");
+
+    return this;
+  }
+
+  public boolean getTcpNoDelay() {
+    return "1".equals(options.get(ConnectionHeaderFields.TCP_NODELAY));
+  }
+
+  public Map<String, String> getOptions() {
+    return options;
+  }
+}

--- a/rosjava/src/main/java/org/ros/node/topic/TransportHints.java
+++ b/rosjava/src/main/java/org/ros/node/topic/TransportHints.java
@@ -1,43 +1,33 @@
 package org.ros.node.topic;
 
-import java.util.Map;
-
-import org.ros.internal.transport.ConnectionHeaderFields;
 import org.ros.node.ConnectedNode;
-
-import com.google.common.collect.Maps;
 
 
 /**
  * Provides a way of specifying network transport hints to
- * {@link ConnectedNode#newSubscriber(String, String)} and
- * {@link ConnectedNode#newSubscriber(org.ros.namespace.GraphName, String)}.
+ * {@link ConnectedNode#newSubscriber(org.ros.namespace.GraphName, String, TransportHints)} and
+ * {@link ConnectedNode#newSubscriber(String, String, TransportHints)}.
  *
  * @author stefan.glaser@hs-offenburg.de (Stefan Glaser)
  */
 public class TransportHints {
 
-  Map<String, String> options;
+  private boolean tcpNoDelay;
 
- public TransportHints() {
-   this.options = Maps.newConcurrentMap();
+  public TransportHints() {
+    this(false);
   }
 
   public TransportHints(boolean tcpNoDelay) {
-    tcpNoDelay(tcpNoDelay);
+    this.tcpNoDelay = tcpNoDelay;
   }
 
-  public TransportHints tcpNoDelay(boolean nodelay) {
-    options.put(ConnectionHeaderFields.TCP_NODELAY, nodelay ? "1" : "0");
-
+  public TransportHints tcpNoDelay(boolean tcpNoDelay) {
+    this.tcpNoDelay = tcpNoDelay;
     return this;
   }
 
   public boolean getTcpNoDelay() {
-    return "1".equals(options.get(ConnectionHeaderFields.TCP_NODELAY));
-  }
-
-  public Map<String, String> getOptions() {
-    return options;
+    return tcpNoDelay;
   }
 }


### PR DESCRIPTION
This pull request introduces transport hints to specify the TCP-NO-DELAY option when creating a new subscriber. Furthermore, it also processes the TCP-NO-DELAY header field for incoming subscriber connections and sets this option on the corresponding channel.

For testing purposes I've modified the pubsub tutorial to exchange messages in 1000Hz. I've tested rosjava (subscriber) to rosjava (publisher) as well as rosjava (subscriber) to rospy (publisher). The roscore and subscriber were running on my PC and the publisher on a RasPi 3b, connected via a dedicated router. The transmitted messages were monitored in Wireshark. Both tests worked as expected.

Wireshark results:
1.  TCP-NO-DELAY on
    ![rosjava_tcp_no_delay_on](https://user-images.githubusercontent.com/12541875/55490651-60924e80-5634-11e9-87a0-60a27481384c.png)

2.  TCP-NO-DELAY off
    ![rosjava_tcp_no_delay_off](https://user-images.githubusercontent.com/12541875/55490681-6e47d400-5634-11e9-870e-678152ec106d.png)

The packets in the second screenshot that are not present in the first screenshot are packets that contain more than one ros message.


As there exists a connection buffer / pool in rosjava, I'm not 100% sure what happens if there are two subscribers to the same topic within a rosjava process, one with TCP-NO-DELAY disabled and one with the option enabled. My current expectation is that the first connection that is established decides if TCP-NO-DELAY is enabled or disabled for the corresponding channel. I didn't include the transport hints within the equals method of the ```TopicDeclaration``` class, as I wasn't sure what effects this will imply.

This pull request solves issue #292.