### PR TITLE
Fix for failing tests in class MasterRegistrationTest.

### DIFF
--- a/rosjava/src/test/java/org/ros/internal/node/MasterRegistrationTest.java
+++ b/rosjava/src/test/java/org/ros/internal/node/MasterRegistrationTest.java
@@ -73,4 +73,25 @@ public class MasterRegistrationTest extends RosTest {
     publisher.shutdown();
     assertTrue(publisherListener.awaitMasterUnregistrationSuccess(1, TimeUnit.SECONDS));
   }
+
+  @Test
+  public void testUnregisterPublisherFailure() throws InterruptedException {
+    publisherListener = CountDownPublisherListener.newDefault();
+    nodeMainExecutor.execute(new AbstractNodeMain() {
+      @Override
+      public GraphName getDefaultNodeName() {
+        return GraphName.of("node");
+      }
+
+      @Override
+      public void onStart(ConnectedNode connectedNode) {
+        publisher = connectedNode.newPublisher("topic", std_msgs.String._TYPE);
+        publisher.addListener(publisherListener);
+      }
+    }, nodeConfiguration);
+    assertTrue(publisherListener.awaitMasterRegistrationSuccess(1, TimeUnit.SECONDS));
+    rosCore.shutdown();
+    publisher.shutdown();
+    assertTrue(publisherListener.awaitMasterUnregistrationFailure(6, TimeUnit.SECONDS));
+  }
 }


### PR DESCRIPTION
Waits for all signals to be delivered before shutting down listeners.
Creates new testUnregisterPublisherFailure() test in class MasterRegistrationTest.
closes #268 